### PR TITLE
fix set to local storage

### DIFF
--- a/src/contexts/MovieContext.jsx
+++ b/src/contexts/MovieContext.jsx
@@ -14,6 +14,7 @@ export const MovieProvider = ({children}) => {
     }, [])
 
     useEffect(() => {
+        if(favorites.length>0)
         localStorage.setItem('favorites', JSON.stringify(favorites))
     }, [favorites])
 


### PR DESCRIPTION
there is a small bug in 2nd useEffect when the page is initially rendering as favorites is empty so it will set local storage emtpy